### PR TITLE
Update of templates for creating .deb packages and uploading Cyberfox to ppa

### DIFF
--- a/_Build/_Linux/build_deb_and_ppa_package_beta.sh
+++ b/_Build/_Linux/build_deb_and_ppa_package_beta.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # Built from template by hawkeye116477
 # Full repo https://github.com/hawkeye116477/cyberfox-deb
-# Script Version: 1.0
+# Script Version: 1.1
 
 # Init vars
 VERSION=""
 
 # Get package version including beta version if beta.
-if [ -f "../../../browser/config/version_display.txt" ]; then
-    VERSION=$(<../../../browser/config/version_display.txt)
+if [ -f "../../../../browser/config/version_display.txt" ]; then
+    VERSION=$(<../../../../browser/config/version_display.txt)
 else
     echo "Unable to get current build version!"
     exit 1    
@@ -19,27 +19,27 @@ Dir=$(cd "$(dirname "$0")" && pwd)
 cd $Dir/
 mkdir debs # Create folder where move created .deb packages
 mkdir deb_and_ppa_beta
-cd $Dir/deb_and_ppa_beta/
+cd $Dir/deb_and_ppa_beta
 mkdir cyberfox-$VERSION
-cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/
+cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION
 mkdir debian
 mkdir usr
-cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/
+cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr
 mkdir share
-cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/share/
+cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/share
 mkdir applications
 mkdir lintian
-cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/
+cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr
 mkdir lib
-cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/lib/
+cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/lib
 mkdir Cyberfox
 
-#Set current directory to directory of package.
+# Set current directory to directory of package.
 cd $Dir/deb_and_ppa_beta/cyberfox-$VERSION
 
 # Copy PPA templates
-if [ -f "$Dir/deb_and_ppa_templates/beta/" ]; then
-	cp -avr $Dir/deb_and_ppa_templates/beta/ $Dir/deb_and_ppa_beta/cyberfox-$VERSION/debian/
+if [ -f "$Dir/deb_and_ppa_templates/beta" ]; then
+	cp -avr $Dir/deb_and_ppa_templates/beta $Dir/deb_and_ppa_beta/cyberfox-$VERSION/debian
 else
     echo "Unable to locate ppa beta templates!"
     exit 1 
@@ -54,8 +54,8 @@ else
 fi
 
 # Copy latest build
-if [ -d "../../../../obj64/dist/Cyberfox" ]; then
-    cp -R ../../../../obj64/dist/Cyberfox/* $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/lib/Cyberfox
+if [ -d "../../../../../obj64/dist/Cyberfox" ]; then
+    cp -R ../../../../../obj64/dist/Cyberfox/* $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/lib/Cyberfox
 	cp $Dir/deb_and_ppa_templates/cyberfox.desktop $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/share/applications
 	cp $Dir/deb_and_ppa_templates/Cyberfox $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/share/lintian/overrides
     cp $Dir/deb_and_ppa_templates/Cyberfox.sh $Dir/deb_and_ppa_beta/cyberfox-$VERSION
@@ -64,7 +64,7 @@ else
     echo "Unable to Cyberfox package files, Please check the build was created and packaged successfully!"
     exit 1     
 fi
-
+	
 # Make sure correct permissions are set
 chmod  755 $Dir/deb_and_ppa_beta/cyberfox-$VERSION/debian/control
 chmod  755 $Dir/deb_and_ppa_beta/cyberfox-$VERSION/debian/prerm
@@ -74,9 +74,13 @@ chmod  755 $Dir/deb_and_ppa_beta/cyberfox-$VERSION/debian/copyright
 ln -s /usr/lib/Cyberfox/Cyberfox.sh $Dir/deb_and_ppa_beta/cyberfox-$VERSION/cyberfox
 ln -s /usr/lib/Cyberfox/browser/icons/mozicon128.png $Dir/deb_and_ppa_beta/cyberfox-$VERSION/Cyberfox.png
 
+# Linux has hunspell dictionaries, so we can remove Cyberfox dictionaries and make symlink to Linux dictionaries. Thanks to this, we don't have to download dictionary from AMO for our language.
+rm -rf $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries
+ln -s /usr/share/hunspell $Dir/deb_and_ppa_beta/cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries
+
 # Build .deb package
-debuild -us
-mv $Dir/deb_and_ppa_beta/cyberfox-$VERSION-0~ppa1_amd64.deb $Dir/debs/Cyberfox-$VERSION.en-US.linux-x86_64.deb
+debuild -us -uc
+mv $Dir/deb_and_ppa_beta/cyberfox-$VERSION_amd64.deb $Dir/debs/Cyberfox-$VERSION.en-US.linux-x86_64.deb
 
 # Build package for upload to PPA
 debuild -S -sa

--- a/_Build/_Linux/build_deb_and_ppa_package_stable.sh
+++ b/_Build/_Linux/build_deb_and_ppa_package_stable.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # Built from template by hawkeye116477
 # Full repo https://github.com/hawkeye116477/cyberfox-deb
-# Script Version: 1.0
+# Script Version: 1.1
 
 # Init vars
 VERSION=""
 
 # Get package version.
-if [ -f "../../../browser/config/version_display.txt" ]; then
-    VERSION=$(<../../../browser/config/version_display.txt)
+if [ -f "../../../../browser/config/version_display.txt" ]; then
+    VERSION=$(<../../../../browser/config/version_display.txt)
 else
     echo "Unable to get current build version!"
     exit 1    
@@ -19,27 +19,28 @@ Dir=$(cd "$(dirname "$0")" && pwd)
 cd $Dir/
 mkdir debs # Create folder where move created .deb packages
 mkdir deb_and_ppa_stable
-cd $Dir/deb_and_ppa_stable/
+cd $Dir/deb_and_ppa_stable
 mkdir cyberfox-$VERSION
-cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/
+cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION
 mkdir debian 
 mkdir usr
-cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/
+mkdir locales #Create folder where put locales.xpi
+cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr
 mkdir share
-cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/share/
+cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/share
 mkdir applications
 mkdir lintian
-cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/
+cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr
 mkdir lib
-cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/
+cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib
 mkdir Cyberfox
 
-#Set current directory to directory of package.
+# Set current directory to directory of package.
 cd $Dir/deb_and_ppa_stable/cyberfox-$VERSION
 
 # Copy PPA templates
-if [ -f "$Dir/deb_and_ppa_templates/stable/" ]; then
-	cp -avr $Dir/deb_and_ppa_templates/stable/ $Dir/deb_and_ppa_stable/cyberfox-$VERSION/debian/
+if [ -f "$Dir/deb_and_ppa_templates/stable" ]; then
+	cp -avr $Dir/deb_and_ppa_templates/stable $Dir/deb_and_ppa_stable/cyberfox-$VERSION/debian
 else
     echo "Unable to locate ppa templates!"
     exit 1 
@@ -54,8 +55,8 @@ else
 fi
 
 # Copy latest build
-if [ -d "../../../../obj64/dist/Cyberfox" ]; then
-    cp -R ../../../../obj64/dist/Cyberfox/* $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/Cyberfox
+if [ -d "../../../../../obj64/dist/Cyberfox" ]; then
+    cp -R ../../../../../obj64/dist/Cyberfox/* $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/Cyberfox
 	cp $Dir/deb_and_ppa_templates/cyberfox.desktop $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/share/applications
 	cp $Dir/deb_and_ppa_templates/Cyberfox $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/share/lintian/overrides
     cp $Dir/deb_and_ppa_templates/Cyberfox.sh $Dir/deb_and_ppa_stable/cyberfox-$VERSION
@@ -65,8 +66,10 @@ else
     exit 1     
 fi
 
+# Copy language packs. Copy .xpi to $Dir/deb_and_ppa_stable/cyberfox-$VERSION/locales. Need to add commands here. 
+
 # Make sure correct permissions are set
-chmod  755 $Dir/deb_and_ppa_/cyberfox-$VERSION/debian/control
+chmod  755 $Dir/deb_and_ppa_stable/cyberfox-$VERSION/debian/control
 chmod  755 $Dir/deb_and_ppa_stable/cyberfox-$VERSION/debian/prerm
 chmod  755 $Dir/deb_and_ppa_stable/cyberfox-$VERSION/debian/copyright
 
@@ -74,9 +77,13 @@ chmod  755 $Dir/deb_and_ppa_stable/cyberfox-$VERSION/debian/copyright
 ln -s /usr/lib/Cyberfox/Cyberfox.sh $Dir/deb_and_ppa_stable/cyberfox-$VERSION/cyberfox
 ln -s /usr/lib/Cyberfox/browser/icons/mozicon128.png $Dir/deb_and_ppa_stable/cyberfox-$VERSION/Cyberfox.png
 
+# Linux has hunspell dictionaries, so we can remove Cyberfox dictionaries and make symlink to Linux dictionaries. Thanks to this, we don't have to download dictionary from AMO for our language.
+rm -rf $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries
+ln -s /usr/share/hunspell $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries
+
 # Build .deb package
-debuild -us
-mv $Dir/deb_and_ppa_stable/cyberfox-$VERSION-0~ppa1_amd64.deb $Dir/debs/Cyberfox-$VERSION.en-US.linux-x86_64.deb
+debuild -us -uc
+mv $Dir/deb_and_ppa_stable/cyberfox-$VERSION_amd64.deb $Dir/debs/Cyberfox-$VERSION.en-US.linux-x86_64.deb
 
 # Build package for upload to PPA
 debuild -S -sa

--- a/_Build/_Linux/build_deb_and_ppa_package_stable_unity-edition.sh
+++ b/_Build/_Linux/build_deb_and_ppa_package_stable_unity-edition.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 # Built from template by hawkeye116477
 # Full repo https://github.com/hawkeye116477/cyberfox-deb
-# Script Version: 1.0
+# Script Version: 1.1
 
 # Init vars
 VERSION=""
 
 # Get package version.
-if [ -f "../../../browser/config/version_display.txt" ]; then
-    VERSION=$(<../../../browser/config/version_display.txt)
+if [ -f "../../../../browser/config/version_display.txt" ]; then
+    VERSION=$(<../../../../browser/config/version_display.txt)
 else
     echo "Unable to get current build version!"
     exit 1    
@@ -19,27 +19,27 @@ Dir=$(cd "$(dirname "$0")" && pwd)
 cd $Dir/
 mkdir debs # Create folder where move created .deb packages
 mkdir deb_and_ppa_stable
-cd $Dir/deb_and_ppa_stable/
+cd $Dir/deb_and_ppa_stable
 mkdir cyberfox-unity-edition-$VERSION
-cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/
+cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION
 mkdir debian
 mkdir usr
-cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/
+cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr
 mkdir share
-cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/share/
+cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/share
 mkdir applications
 mkdir lintian
-cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/
+cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr
 mkdir lib
-cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/lib/
+cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/lib
 mkdir Cyberfox
 
 # Set current directory to directory of package.
 cd $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION
 
 # Copy PPA templates
-if [ -f "$Dir/deb_and_ppa_templates/stable_unity-edition/" ]; then
-	cp -avr $Dir/deb_and_ppa_templates/stable_unity-edition/ $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/debian/
+if [ -f "$Dir/deb_and_ppa_templates/stable_unity-edition" ]; then
+	cp -avr $Dir/deb_and_ppa_templates/stable_unity-edition $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/debian
 else
     echo "Unable to locate deb & ppa templates!"
     exit 1 
@@ -54,8 +54,8 @@ else
 fi
 
 # Copy latest build
-if [ -d "../../../../obj64/dist/Cyberfox" ]; then
-    cp -R ../../../../obj64/dist/Cyberfox/* $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/lib/Cyberfox
+if [ -d "../../../../../obj64/dist/Cyberfox" ]; then
+    cp -R ../../../../../obj64/dist/Cyberfox/* $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/lib/Cyberfox
 	cp $Dir/deb_and_ppa_templates/cyberfox.desktop $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/share/applications
 	cp $Dir/deb_and_ppa_templates/Cyberfox $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/usr/share/lintian/overrides
     cp $Dir/deb_and_ppa_templates/Cyberfox.sh $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION
@@ -74,9 +74,13 @@ chmod  755 $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/debian/copyri
 ln -s /usr/lib/Cyberfox/Cyberfox.sh $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/cyberfox
 ln -s /usr/lib/Cyberfox/browser/icons/mozicon128.png $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION/Cyberfox.png
 
+# Linux has hunspell dictionaries, so we can remove Cyberfox dictionaries and make symlink to Linux dictionaries. Thanks to this, we don't have to download dictionary from AMO for our language.
+rm -rf $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries
+ln -s /usr/share/hunspell $Dir/deb_and_ppa_stable/cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries
+
 # Build .deb package
-debuild -us
-mv $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION-0~ppa1_amd64.deb $Dir/debs/cyberfox-unity-edition-$VERSION.en-US.linux-x86_64.deb
+debuild -us -uc
+mv $Dir/deb_and_ppa_stable/cyberfox-unity-edition-$VERSION_amd64.deb $Dir/debs/cyberfox-unity-edition-$VERSION.en-US.linux-x86_64.deb
 
 # Build package for upload to PPA
 debuild -S -sa

--- a/_Build/_Linux/deb_and_ppa_templates/beta/changelog
+++ b/_Build/_Linux/deb_and_ppa_templates/beta/changelog
@@ -1,4 +1,4 @@
-cyberfox (49.0b7-0~ppa1) xenial; urgency=low
+cyberfox (49.0b7) xenial; urgency=low
 
   * Changelog is here ---> https://github.com/InternalError503/cyberfox-beta/releases
 

--- a/_Build/_Linux/deb_and_ppa_templates/stable/changelog
+++ b/_Build/_Linux/deb_and_ppa_templates/stable/changelog
@@ -1,4 +1,4 @@
-cyberfox (48.0.2-0~ppa1) xenial; urgency=low
+cyberfox (48.0.2) xenial; urgency=low
 
   * Changelog is here ---> https://cyberfox.8pecxstudios.com/hooray-your-cyberfox-is-up-to-date/?version=48.0.2
 

--- a/_Build/_Linux/deb_and_ppa_templates/stable/control
+++ b/_Build/_Linux/deb_and_ppa_templates/stable/control
@@ -23,3 +23,553 @@ Description: Fast, stable & reliable x64-bit web browser
  Taking over where Mozilla left off, 
  Working to make a fast, stable & reliable x64-bit web browser accessible to all.
  Cyberfox is powered by Mozilla Firefox source code.
+
+Package: cyberfox-locale-af
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Afrikaans language pack for Cyberfox
+ This package contains Afrikaans translations for Cyberfox
+
+Package: cyberfox-locale-an
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Aragonese language pack for Cyberfox
+ This package contains Aragonese translations for Cyberfox
+
+Package: cyberfox-locale-ar
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Arabic language pack for Cyberfox
+ This package contains Arabic translations for Cyberfox
+
+Package: cyberfox-locale-as
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Assamese language pack for Cyberfox
+ This package contains Assamese translations for Cyberfox
+
+Package: cyberfox-locale-ast
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Asturian language pack for Cyberfox
+ This package contains Asturian translations for Cyberfox
+
+Package: cyberfox-locale-az
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Azerbaijani language pack for Cyberfox
+ This package contains Azerbaijani translations for Cyberfox
+
+Package: cyberfox-locale-be
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Belarusian language pack for Cyberfox
+ This package contains Belarusian translations for Cyberfox
+
+Package: cyberfox-locale-bg
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Bulgarian language pack for Cyberfox
+ This package contains Bulgarian translations for Cyberfox
+
+Package: cyberfox-locale-bn
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Bengali language pack for Cyberfox
+ This package contains Bengali translations for Cyberfox
+
+Package: cyberfox-locale-br
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Breton language pack for Cyberfox
+ This package contains Breton translations for Cyberfox
+
+Package: cyberfox-locale-bs
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Bosnian language pack for Cyberfox
+ This package contains Bosnian translations for Cyberfox
+
+Package: cyberfox-locale-ca
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Catalan; Valencian language pack for Cyberfox
+ This package contains Catalan; Valencian translations for Cyberfox
+
+Package: cyberfox-locale-cak
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Kaqchikel language pack for Cyberfox
+ This package contains Kaqchikel translations for Cyberfox
+
+Package: cyberfox-locale-cs
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Czech language pack for Cyberfox
+ This package contains Czech translations for Cyberfox
+
+Package: cyberfox-locale-csb
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-cy
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Welsh language pack for Cyberfox
+ This package contains Welsh translations for Cyberfox
+
+Package: cyberfox-locale-da
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Danish language pack for Cyberfox
+ This package contains Danish translations for Cyberfox
+
+Package: cyberfox-locale-de
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: German language pack for Cyberfox
+ This package contains German translations for Cyberfox
+
+Package: cyberfox-locale-el
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Greek language pack for Cyberfox
+ This package contains Greek translations for Cyberfox
+
+Package: cyberfox-locale-en
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: English language pack for Cyberfox
+ This package contains English translations for Cyberfox
+
+Package: cyberfox-locale-eo
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Esperanto language pack for Cyberfox
+ This package contains Esperanto translations for Cyberfox
+
+Package: cyberfox-locale-es
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Spanish; Castilian language pack for Cyberfox
+ This package contains Spanish; Castilian translations for Cyberfox
+
+Package: cyberfox-locale-et
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Estonian language pack for Cyberfox
+ This package contains Estonian translations for Cyberfox
+
+Package: cyberfox-locale-eu
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Basque language pack for Cyberfox
+ This package contains Basque translations for Cyberfox
+
+Package: cyberfox-locale-fa
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Persian language pack for Cyberfox
+ This package contains Persian translations for Cyberfox
+
+Package: cyberfox-locale-fi
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Finnish language pack for Cyberfox
+ This package contains Finnish translations for Cyberfox
+
+Package: cyberfox-locale-fr
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: French language pack for Cyberfox
+ This package contains French translations for Cyberfox
+
+Package: cyberfox-locale-fy
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Western Frisian language pack for Cyberfox
+ This package contains Western Frisian translations for Cyberfox
+
+Package: cyberfox-locale-ga
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Irish language pack for Cyberfox
+ This package contains Irish translations for Cyberfox
+
+Package: cyberfox-locale-gd
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Gaelic; Scottish Gaelic language pack for Cyberfox
+ This package contains Gaelic; Scottish Gaelic translations for Cyberfox
+
+Package: cyberfox-locale-gl
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Galician language pack for Cyberfox
+ This package contains Galician translations for Cyberfox
+
+Package: cyberfox-locale-gn
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Guarani language pack for Cyberfox
+ This package contains Guarani translations for Cyberfox
+
+Package: cyberfox-locale-gu
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Gujarati language pack for Cyberfox
+ This package contains Gujarati translations for Cyberfox
+
+Package: cyberfox-locale-he
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Hebrew language pack for Cyberfox
+ This package contains Hebrew translations for Cyberfox
+
+Package: cyberfox-locale-hi
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Hindi language pack for Cyberfox
+ This package contains Hindi translations for Cyberfox
+
+Package: cyberfox-locale-hr
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Croatian language pack for Cyberfox
+ This package contains Croatian translations for Cyberfox
+
+Package: cyberfox-locale-hsb
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Sorbian, Upper language pack for Cyberfox
+ This package contains Sorbian, Upper translations for Cyberfox
+
+Package: cyberfox-locale-hu
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Hungarian language pack for Cyberfox
+ This package contains Hungarian translations for Cyberfox
+
+Package: cyberfox-locale-hy
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Armenian language pack for Cyberfox
+ This package contains Armenian translations for Cyberfox
+
+Package: cyberfox-locale-id
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Indonesian language pack for Cyberfox
+ This package contains Indonesian translations for Cyberfox
+
+Package: cyberfox-locale-is
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Icelandic language pack for Cyberfox
+ This package contains Icelandic translations for Cyberfox
+
+Package: cyberfox-locale-it
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Italian language pack for Cyberfox
+ This package contains Italian translations for Cyberfox
+
+Package: cyberfox-locale-ja
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Japanese language pack for Cyberfox
+ This package contains Japanese translations for Cyberfox
+
+Package: cyberfox-locale-ka
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-kk
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Kazakh language pack for Cyberfox
+ This package contains Kazakh translations for Cyberfox
+
+Package: cyberfox-locale-km
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Central Khmer language pack for Cyberfox
+ This package contains Central Khmer translations for Cyberfox
+
+Package: cyberfox-locale-kn
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Kannada language pack for Cyberfox
+ This package contains Kannada translations for Cyberfox
+
+Package: cyberfox-locale-ko
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Korean language pack for Cyberfox
+ This package contains Korean translations for Cyberfox
+
+Package: cyberfox-locale-ku
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-lg
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-lt
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Lithuanian language pack for Cyberfox
+ This package contains Lithuanian translations for Cyberfox
+
+Package: cyberfox-locale-lv
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Latvian language pack for Cyberfox
+ This package contains Latvian translations for Cyberfox
+
+Package: cyberfox-locale-mai
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Maithili language pack for Cyberfox
+ This package contains Maithili translations for Cyberfox
+
+Package: cyberfox-locale-mk
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Macedonian language pack for Cyberfox
+ This package contains Macedonian translations for Cyberfox
+
+Package: cyberfox-locale-ml
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Malayalam language pack for Cyberfox
+ This package contains Malayalam translations for Cyberfox
+
+Package: cyberfox-locale-mn
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-mr
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Marathi language pack for Cyberfox
+ This package contains Marathi translations for Cyberfox
+
+Package: cyberfox-locale-ms
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Malay language pack for Cyberfox
+ This package contains Malay translations for Cyberfox
+
+Package: cyberfox-locale-nb
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Bokmål, Norwegian; Norwegian Bokmål language pack for Cyberfox
+ This package contains Bokmål, Norwegian; Norwegian Bokmål translations for Cyberfox
+
+Package: cyberfox-locale-nl
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Dutch; Flemish language pack for Cyberfox
+ This package contains Dutch; Flemish translations for Cyberfox
+
+Package: cyberfox-locale-nn
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Norwegian Nynorsk; Nynorsk, Norwegian language pack for Cyberfox
+ This package contains Norwegian Nynorsk; Nynorsk, Norwegian translations for Cyberfox
+
+Package: cyberfox-locale-nso
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-oc
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-or
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Oriya language pack for Cyberfox
+ This package contains Oriya translations for Cyberfox
+
+Package: cyberfox-locale-pa
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Panjabi; Punjabi language pack for Cyberfox
+ This package contains Panjabi; Punjabi translations for Cyberfox
+
+Package: cyberfox-locale-pl
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Polish language pack for Cyberfox
+ This package contains Polish translations for Cyberfox
+
+Package: cyberfox-locale-pt
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Portuguese language pack for Cyberfox
+ This package contains Portuguese translations for Cyberfox
+
+Package: cyberfox-locale-ro
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Romanian language pack for Cyberfox
+ This package contains Romanian translations for Cyberfox
+
+Package: cyberfox-locale-ru
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Russian language pack for Cyberfox
+ This package contains Russian translations for Cyberfox
+
+Package: cyberfox-locale-si
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Sinhala; Sinhalese language pack for Cyberfox
+ This package contains Sinhala; Sinhalese translations for Cyberfox
+
+Package: cyberfox-locale-sk
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Slovak language pack for Cyberfox
+ This package contains Slovak translations for Cyberfox
+
+Package: cyberfox-locale-sl
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Slovenian language pack for Cyberfox
+ This package contains Slovenian translations for Cyberfox
+
+Package: cyberfox-locale-sq
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Albanian language pack for Cyberfox
+ This package contains Albanian translations for Cyberfox
+
+Package: cyberfox-locale-sr
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Serbian language pack for Cyberfox
+ This package contains Serbian translations for Cyberfox
+
+Package: cyberfox-locale-sv
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Swedish language pack for Cyberfox
+ This package contains Swedish translations for Cyberfox
+
+Package: cyberfox-locale-sw
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+
+Package: cyberfox-locale-ta
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Tamil language pack for Cyberfox
+ This package contains Tamil translations for Cyberfox
+
+Package: cyberfox-locale-te
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Telugu language pack for Cyberfox
+ This package contains Telugu translations for Cyberfox
+
+Package: cyberfox-locale-th
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Thai language pack for Cyberfox
+ This package contains Thai translations for Cyberfox
+
+Package: cyberfox-locale-tr
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Turkish language pack for Cyberfox
+ This package contains Turkish translations for Cyberfox
+
+Package: cyberfox-locale-uk
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Ukrainian language pack for Cyberfox
+ This package contains Ukrainian translations for Cyberfox
+
+Package: cyberfox-locale-uz
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Uzbek language pack for Cyberfox
+ This package contains Uzbek translations for Cyberfox
+
+Package: cyberfox-locale-vi
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Vietnamese language pack for Cyberfox
+ This package contains Vietnamese translations for Cyberfox
+
+Package: cyberfox-locale-xh
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Xhosa language pack for Cyberfox
+ This package contains Xhosa translations for Cyberfox
+
+Package: cyberfox-locale-zh-hans
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Simplified Chinese language pack for Cyberfox
+ This package contains Simplified Chinese translations for Cyberfox
+
+Package: cyberfox-locale-zh-hant
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Traditional Chinese language pack for Cyberfox
+ This package contains Traditional Chinese translations for Cyberfox
+
+Package: cyberfox-locale-zu
+Architecture: amd64
+Depends: ${misc:Depends}
+Description: Transitional package for unavailable language
+ This language is unavailable for the current version of Cyberfox
+ .
+ This is an empty transitional package to ensure a clean upgrade
+ process. You can safely remove this package after installation.
+

--- a/_Build/_Linux/deb_and_ppa_templates/stable/cyberfox-locale-pl.install
+++ b/_Build/_Linux/deb_and_ppa_templates/stable/cyberfox-locale-pl.install
@@ -1,0 +1,1 @@
+/locales/langpack-pl@8pecxstudios.com.xpi /usr/lib/Cyberfox/distribution/extensions/

--- a/_Build/_Linux/deb_and_ppa_templates/stable_unity-edition/changelog
+++ b/_Build/_Linux/deb_and_ppa_templates/stable_unity-edition/changelog
@@ -1,4 +1,4 @@
-cyberfox-unity-edition (48.0.2-0~ppa1) xenial; urgency=low
+cyberfox-unity-edition (48.0.2) xenial; urgency=low
 
   * Changelog is here ---> https://cyberfox.8pecxstudios.com/hooray-your-cyberfox-is-up-to-date/?version=48.0.2
 


### PR DESCRIPTION
I fixed some things and also added to script creating folder where you put locales (for stable version). You must only add commands to copy langpacks.xpi to $Dir/deb_and_ppa_stable/cyberfox-$VERSION/locales and add files cyberfox-locale-xx.install to ppa/templates/ and write in this files something like what I wrote in cyberfox-locale-pl.install (/locales/langpack-pl@8pecxstudios.com.xpi /usr/lib/Cyberfox/distribution/extensions/). You can change some things in control file (add/remove locales packages).

I also removed "-0~ppa1" from changelog file, because this special versioning is only needed "if you're creating an alternative version of a package already available in Ubuntu's repositories" (https://help.launchpad.net/Packaging/PPA/BuildingASourcePackage#Versioning). 

I also added to script - creating symlink to /usr/share/hunspell in $Dir/deb_and_ppa_...../cyberfox-$VERSION/usr/lib/Cyberfox/dictionaries/. Thanks to this, users don't have to download dictionary from AMO for their language.

You can change copyright file. I attached you how look like Firefox copyright file.
[firefox_copyright.zip](https://github.com/InternalError503/cyberfox-beta/files/451582/firefox_copyright.zip)
