### PR TITLE
Update of deb and PPA templates

### DIFF
--- a/_Build/_Linux/build_deb_and_ppa_package_stable.sh
+++ b/_Build/_Linux/build_deb_and_ppa_package_stable.sh
@@ -104,7 +104,7 @@ fi
 if [ -d "../../../../../obj64/dist/Cyberfox" ]; then
     cp -r ../../../../../obj64/dist/Cyberfox/* $Dir/deb_ppa/cyberfox-$VERSION/usr/lib/Cyberfox
 	cp $Dir/deb_and_ppa_templates/cyberfox.desktop $Dir/deb_ppa/cyberfox-$VERSION/usr/share/applications
-	#cp $Dir/deb_and_ppa_templates/Cyberfox $Dir/deb_ppa/cyberfox-$VERSION/usr/share/lintian/overrides #throws error file missing ?
+	cp $Dir/deb_and_ppa_templates/Cyberfox $Dir/deb_ppa/cyberfox-$VERSION/usr/share/lintian/overrides
     cp $Dir/deb_and_ppa_templates/Cyberfox.sh $Dir/deb_ppa/cyberfox-$VERSION
 	cp $Dir/deb_and_ppa_templates/vendor-gre.js $Dir/deb_ppa/cyberfox-$VERSION
 else

--- a/_Build/_Linux/build_deb_and_ppa_package_stable.sh
+++ b/_Build/_Linux/build_deb_and_ppa_package_stable.sh
@@ -13,13 +13,13 @@ IDENTITY=$2
 
 # Check if source code url was passed to script
 if [ -z "$SOURCE" ] || [ ! -n "$SOURCE" ]; then
-    echo "Source url must be passed to the script build_deb_package.sh 'URL'"
+    echo "Source url must be passed to the script build_deb_and_ppa_package.sh 'URL'"
     exit 1
 fi
 
 # Check if IDENTITY was passed to script
 if [ -z "$IDENTITY" ] || [ ! -n "$IDENTITY" ]; then
-    echo "IDENTITY type must be passed to the script build_deb_package.sh 'IDENTITY'"
+    echo "IDENTITY type must be passed to the script build_deb_and_ppa_package.sh 'IDENTITY'"
     exit 1
 fi
 
@@ -63,13 +63,24 @@ fi
 # Set current directory to directory of package.
 cd $Dir/deb_ppa/cyberfox-$VERSION
 
-# Copy PPA templates
+# Copy DEB and PPA templates
 if [ -d "$Dir/deb_and_ppa_templates/_template" ]; then
 	cp -r $Dir/deb_and_ppa_templates/_template/* $Dir/deb_ppa/cyberfox-$VERSION/debian
 else
     echo "Unable to locate ppa templates!"
     exit 1 
 fi
+
+# Copy control file
+if [ -d "$Dir/deb_and_ppa_templates/" ]; then
+if [ "$IDENTITY" == "Release" ]; then
+	mv $Dir/deb_and_ppa_templates/control.release $Dir/deb_ppa/cyberfox-$VERSION/debian/control
+else if [ "$IDENTITY" == "Beta" ]; then
+	mv $Dir/deb_and_ppa_templates/control.beta $Dir/deb_ppa/cyberfox-$VERSION/debian/control
+else
+    echo "IDENTITY was not set. Unable to copy control file!"
+    exit 1 
+fi	
 
 # Generate change log template
 CHANGELOGDIR=$Dir/deb_ppa/cyberfox-$VERSION/debian/changelog
@@ -102,7 +113,7 @@ fi
 
 # Copy latest build
 if [ -d "../../../../../obj64/dist/Cyberfox" ]; then
-    cp -r ../../../../../obj64/dist/Cyberfox/* $Dir/deb_ppa/cyberfox-$VERSION/usr/lib/Cyberfox
+    cp -r ../../../../../obj64/dist/Cyberfox/* $Dir/deb_ppa/cyberfox-$VERSION/Cyberfox
 	cp $Dir/deb_and_ppa_templates/cyberfox.desktop $Dir/deb_ppa/cyberfox-$VERSION/usr/share/applications
 	cp $Dir/deb_and_ppa_templates/Cyberfox $Dir/deb_ppa/cyberfox-$VERSION/usr/share/lintian/overrides
     cp $Dir/deb_and_ppa_templates/Cyberfox.sh $Dir/deb_ppa/cyberfox-$VERSION
@@ -116,6 +127,7 @@ fi
 if [ ! "$IDENTITY" == "Release" ]; then
     # ToDo: Pull latest applicable language packs when release package, Don't package for beta.
     rm -f $Dir/deb_ppa/cyberfox-$VERSION/debian/cyberfox-locale-pl.install
+	rm -f $Dir/deb_ppa/cyberfox-$VERSION/debian/cyberfox-unity-edition.install
 fi
 
 # Make sure correct permissions are set

--- a/_Build/_Linux/deb_and_ppa_templates/Cyberfox
+++ b/_Build/_Linux/deb_and_ppa_templates/Cyberfox
@@ -1,0 +1,3 @@
+Cyberfox binary: embedded-library usr/lib/Cyberfox/libxul.so: libjpeg
+Cyberfox binary: embedded-library usr/lib/Cyberfox/libmozsqlite3.so: sqlite
+Cyberfox binary: image-file-in-usr-lib

--- a/_Build/_Linux/deb_and_ppa_templates/_template/cyberfox-unity-edition.install
+++ b/_Build/_Linux/deb_and_ppa_templates/_template/cyberfox-unity-edition.install
@@ -3,4 +3,4 @@ vendor-gre.js /usr/lib/Cyberfox/defaults/pref/
 Cyberfox.sh /usr/lib/Cyberfox/
 Cyberfox.png /usr/share/pixmaps/
 cyberfox /usr/bin/
-Cyberfox/* /usr/lib/Cyberfox
+Cyberfox-unity-edition/* /usr/lib/Cyberfox

--- a/_Build/_Linux/deb_and_ppa_templates/control.beta
+++ b/_Build/_Linux/deb_and_ppa_templates/control.beta
@@ -1,0 +1,28 @@
+Source: cyberfox
+Section: web
+Priority: optional
+Maintainer: 8pecxstudios <support@8pecxstudios.com>
+Uploaders: hawkeye116477 <hawkeye116477@gmail.com>
+Build-Depends:debhelper (>= 7),
+Standards-Version: 3.9.7
+Homepage: https://cyberfox.8pecxstudios.com/
+
+Package: cyberfox
+Architecture: amd64
+Depends: lsb-release,
+	${misc:Depends},
+	libasound2 (>= 1.0.16), libatk1.0-0 (>= 1.12.4), libc6 (>= 2.17), libcairo-gobject2 (>= 1.10.0), libcairo2 (>= 1.10.0), libdbus-glib-1-2 (>= 0.78), libfreetype6 (>= 2.2.1), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.31.8), libgtk-3-0 (>= 3.4), libgtk2.0-0 (>= 2.14), libpango-1.0-0 (>= 1.22.0), libpangocairo-1.0-0 (>= 1.14.0), libstartup-notification0 (>= 0.8), libx11-6, libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxrender1, libxt6
+Recommends: libcanberra0,
+	libdbusmenu-glib4,
+	libdbusmenu-gtk4
+Provides: www-browser,
+	gnome-www-browser,
+Suggests: fonts-lyx,
+Description: Fast, stable & reliable x64-bit web browser
+ Cyberfox is designed by 8pecxstudios, 
+ Taking over where Mozilla left off, 
+ Working to make a fast, stable & reliable x64-bit web browser accessible to all.
+ Cyberfox is powered by Mozilla Firefox source code.
+.
+ This Cyberfox has the standard menu-bar. 
+ Unfortunately, Unity-Edition is not available for beta.

--- a/_Build/_Linux/deb_and_ppa_templates/control.release
+++ b/_Build/_Linux/deb_and_ppa_templates/control.release
@@ -23,6 +23,28 @@ Description: Fast, stable & reliable x64-bit web browser
  Taking over where Mozilla left off, 
  Working to make a fast, stable & reliable x64-bit web browser accessible to all.
  Cyberfox is powered by Mozilla Firefox source code.
+.
+ This Cyberfox has the standard menu-bar. 
+ If you want to have menu-bar in the unity bar at the top of the screen, install cyberfox-unity-edition package.
+
+Package: cyberfox-unity-edition
+Architecture: amd64
+Depends: lsb-release,
+	${misc:Depends},
+	libasound2 (>= 1.0.16), libatk1.0-0 (>= 1.12.4), libc6 (>= 2.17), libcairo-gobject2 (>= 1.10.0), libcairo2 (>= 1.10.0), libdbus-glib-1-2 (>= 0.78), libfreetype6 (>= 2.2.1), libgcc1 (>= 1:4.0), libgdk-pixbuf2.0-0 (>= 2.22.0), libglib2.0-0 (>= 2.31.8), libgtk-3-0 (>= 3.4), libgtk2.0-0 (>= 2.14), libpango-1.0-0 (>= 1.22.0), libpangocairo-1.0-0 (>= 1.14.0), libstartup-notification0 (>= 0.8), libx11-6, libxcomposite1 (>= 1:0.3-1), libxdamage1 (>= 1:1.1), libxext6, libxfixes3, libxrender1, libxt6
+Recommends: libcanberra0,
+	libdbusmenu-glib4,
+	libdbusmenu-gtk4
+Provides: www-browser,
+	gnome-www-browser,
+Suggests: fonts-lyx,
+Description: Fast, stable & reliable x64-bit web browser
+Cyberfox is designed by 8pecxstudios, 
+ Taking over where Mozilla left off, 
+ Working to make a fast, stable & reliable x64-bit web browser accessible to all.
+ Cyberfox is powered by Mozilla Firefox source code.
+.
+ This edition contains a patch from trusty Firefox that makes the browsers menu-bar appear in the unity bar at the top of the screen just like Firefox does.
 
 Package: cyberfox-locale-af
 Architecture: amd64


### PR DESCRIPTION
Welcome Toady!
I added missing file to deb and ppa templates, which I forgot to add previously. 
I also added seperate control file for release and beta, because for beta we don't want unity-edition and locales. 
I also added cyberfox-unity-edition.install file to make standard edition and unity in one package (I added in cyberfox-unity-edition.install that debhelper copy content of folder Cyberfox-unity-edition to usr/lib/Cyberfox and in cyberfox.install added that debhelper copy content of folder Cyberfox to /usr/lib/Cyberfox). 
So you should add similar to script build_deb_and_ppa_package_stable.sh for unity edition (copy only contents of a folder with cyberfox-unity to $Dir/deb_ppa/cyberfox-$VERSION/Cyberfox-unity-edition): cp -r ../../../../../obj64/dist/Cyberfox-unity-edition/* $Dir/deb_ppa/cyberfox-$VERSION/Cyberfox-unity-edition.

In control file, dot on a blank line must be, if we want to debhelper interpret this as a blank line.

What error throws command debuild -us -uc ? 

I recommend Notepadqq for editing templates files and also text files, because Notepadqq has 
numbering lines and wrapping lines and other useful things, which Notepad++ has. So Notepadqq is Notepad++ for Linux. If you want to install Notepadqq, type commands:
sudo add-apt-repository ppa:notepadqq-team/notepadqq
sudo apt-get update
sudo apt-get install notepadqq
