### PR TITLE
Update of deb and ppa templates

### DIFF
--- a/_Build/_Linux/build_deb_and_ppa_package_stable.sh
+++ b/_Build/_Linux/build_deb_and_ppa_package_stable.sh
@@ -127,6 +127,7 @@ chmod  755 $Dir/deb_ppa/cyberfox-$VERSION/debian/control
 chmod  755 $Dir/deb_ppa/cyberfox-$VERSION/debian/cyberfox.prerm
 chmod  755 $Dir/deb_ppa/cyberfox-$VERSION/debian/cyberfox.postinst
 chmod  755 $Dir/deb_ppa/cyberfox-$VERSION/debian/copyright
+chmod  755 $Dir/deb_ppa/cyberfox-$VERSION/debian/rules
 
 # Make symlinks
 ln -s /usr/lib/Cyberfox/Cyberfox.sh $Dir/deb_ppa/cyberfox-$VERSION/cyberfox
@@ -140,10 +141,10 @@ ln -s /usr/share/hunspell $Dir/deb_ppa/cyberfox-$VERSION/usr/lib/Cyberfox/dictio
 # Build .deb package (Requires devscripts to be installed sudo apt install devscripts)
 notify-send "Building deb package!"
 debuild -us -uc #throws error
-if [ -f "$Dir/deb_ppa/cyberfox-$VERSION_amd64.deb" ]; then
-    mv $Dir/deb_ppa/cyberfox-$VERSION_amd64.deb ../../../obj64/dist/Cyberfox-$VERSION.en-US.linux-x86_64.deb
+if [ -f "$Dir/deb_ppa/cyberfox_$VERSION_amd64.deb" ]; then
+    cp $Dir/deb_ppa/cyberfox_$VERSION_amd64.deb ../../../obj64/dist/Cyberfox-$VERSION.en-US.linux-x86_64.deb
 else
-    echo "Unable to move $Dir/deb_ppa/cyberfox-$VERSION_amd64.deb the file maybe missing or had errors during creation!"
+    echo "Unable to move $Dir/deb_ppa/cyberfox_$VERSION_amd64.deb the file maybe missing or had errors during creation!"
     exit 1
 fi
 


### PR DESCRIPTION
Welcome Toady! 
I added missing chmod, because otherwise debhelper complains that debian/rules is executable and changed filename of deb to maybe correct. 
I tested this script on Linux Mint 18, changing identify to beta and directory of cyberfox latest build to where I have this and almost everything works fine, only „Unable to move $Dir/deb_ppa/cyberfox_$VERSION_amd64.deb the file maybe missing or had errors during creation!" appears (I don't know how to fix this error). Error about which you wrote me appears, because you probably haven't fakeroot installed or other required tool. Type this command: `sudo apt-get install build-essential devscripts debhelper dh-make patch gnupg fakeroot lintian` and now should be almost everything fine, only maybe you should correct command with moving deb file.

Remember that you should change copyright file, because this copyright file is from Firefox PPA. „The modules/plugin/base/public/npruntime.h file is licensed under the following terms:": when you upload, you probably don't upload this file, because they did different, they uploaded source code with files needed to upload to PPA and created some python scripts to help. https://launchpad.net/ubuntu/+source/firefox/48.0+build2-0ubuntu1  Ubuntu encourages adding to PPA with source code: „Ubuntu uses Debian's system of packaging software. To get software into a PPA, you need to build a source package. That includes the source code for the software you want to distribute, along with the instructions for where the application should live in the file system and of any dependencies it has on other software. ". 
You can probably do like they, but uploading so large files can take a long time and you have limit on PPA - max 2 GB. If you want to more, you must write to authors of PPA and request more space.
I tried to upload package with source code and folder debian to PPA named test, but something went wrong (maybe some other files needed) and it took a long time. At first I thought that the PPA will only accept a package with source code, but I sent my way without source code and PPA accepted it. 
I got mail „Accepted:
 OK: cyberfox_48.2.0.tar.gz
 OK: cyberfox_48.2.0.dsc
     -> Component: main Section: web "